### PR TITLE
mutation_diversity: replace ref-anchored metric with batch consensus divergence

### DIFF
--- a/config/design/denovo_petase.yaml
+++ b/config/design/denovo_petase.yaml
@@ -108,14 +108,12 @@ reward:
     #     ckpt_name: last.ckpt # checkpoint name to use (usually last.ckpt)
 
     # !! MUTATION DIVERSITY REWARD !!
-    # # reward sequences for contributing unique mutations to the batch.
-    # # outputs both marginal (exclusive-only) and fractional (1/k) scores.
-    # # marginal_count: mutations only this sequence carries (sparse, strong signal)
-    # # fractional_score: sum of 1/k per mutation, k = batch members sharing it (smooth signal)
+    # # Reward sequences for diverging from the per-position batch consensus.
+    # # Reference-free: pushes the policy away from wherever the batch is piling up.
+    # # consensus_divergence: count of positions where this seq's AA is not among the batch modal AA(s).
     # - name: mutation_diversity
     #   target_fn: cleo.design.utils.mutation_diversity.mutation_diversity_from_df
-    #   cfg:
-    #     ref_seq: MGEEEELELERPSGERTPVRRHRFPARKANNIEEAVANVERLIEEIEASGITFTATADRAVVVGWSLGVITGMIMHATGTDFITALRKALEIGKKVKEEDPEFMERHKKIVTDGNRAEIREDIDYWIEVIEKETGHPVDRSRIFIAETVEEAVELARRAVELGHAIIVLPPYLIGTAGEAVVQVLASAGVDVLLMGGLGSGVPVTIYRA
+    #   cfg: {}
 
 
   # Normalizing metrics and aggregating to a single scalar reward
@@ -182,16 +180,9 @@ reward:
     #   weight: 5.0
     #   mode: max
 
-    # !! MUTATION DIVERSITY REWARDS !!
-    # # Use one or both — fractional is smoother, marginal is stricter.
-    # # Track both during training to compare which drives more diversity.
-    # - metric: mutation_diversity_fractional_score
+    # !! MUTATION DIVERSITY REWARD !!
+    # - metric: mutation_diversity_consensus_divergence
     #   lower_bound: 0
-    #   upper_bound: 10    # tune based on batch size and typical mutation counts
-    #   weight: 1.0
-    #   mode: max
-    # - metric: mutation_diversity_marginal_count
-    #   lower_bound: 0
-    #   upper_bound: 10    # tune based on batch size and typical mutation counts
+    #   upper_bound: 30    # tune based on protein length and target diversity
     #   weight: 1.0
     #   mode: max

--- a/src/cleo/design/utils/mutation_diversity.py
+++ b/src/cleo/design/utils/mutation_diversity.py
@@ -1,18 +1,13 @@
 """
-Batch-level mutation diversity rewards for the design pipeline.
+Batch consensus-divergence reward.
 
-Computes per-sequence rewards based on how many unique (position, amino_acid)
-mutations each sequence contributes to a batch, incentivizing the policy to
-explore diverse regions of mutation space rather than converging on the same
-mutations.
+For each sequence in a batch, counts the number of positions where its amino
+acid differs from the batch consensus (the per-position modal AA across the
+batch). Reference-free: rewards being unusual relative to wherever the batch
+is currently piling up, rather than relative to a fixed parent sequence.
 
-Two scoring strategies are provided:
-
-- **Marginal (exclusive)**: A sequence gets credit only for mutations that
-  no other sequence in the batch carries. Sparse signal, strong pressure.
-- **Fractional (1/k)**: Each mutation gives 1/k credit where k is the number
-  of batch members sharing that (position, AA) pair. Smoother signal, more
-  robust to batch size.
+A position with multiple tied modal AAs treats any of them as consensus, so
+sequences aren't penalized for being part of an even split.
 """
 
 from collections import Counter
@@ -20,67 +15,42 @@ from collections import Counter
 import pandas as pd
 
 
-def _get_mutation_sets(sequences, ref_seq):
-    """Build per-sequence sets of (position, amino_acid) mutations vs reference."""
-    mutation_sets = []
-    for seq in sequences:
-        muts = {(i, aa) for i, aa in enumerate(seq) if aa != ref_seq[i]}
-        mutation_sets.append(muts)
-    return mutation_sets
-
-
-def _mutation_counts(mutation_sets):
-    """Count how many sequences carry each (position, AA) mutation."""
-    counts = Counter()
-    for muts in mutation_sets:
-        for m in muts:
-            counts[m] += 1
-    return counts
+def _consensus_sets(sequences):
+    """For each position, return the set of modal AAs (handles ties)."""
+    seq_len = len(sequences[0])
+    consensus = []
+    for i in range(seq_len):
+        counts = Counter(seq[i] for seq in sequences)
+        top = max(counts.values())
+        consensus.append({aa for aa, c in counts.items() if c == top})
+    return consensus
 
 
 def mutation_diversity_from_df(df_input, cfg, step_name="mutation_diversity"):
-    """Compute per-sequence mutation diversity metrics for a batch.
-
-    For each sequence, reports both marginal (exclusive) and fractional (1/k)
-    mutation contribution scores relative to the rest of the batch.
-
-    Config fields:
-        ref_seq (str): Parent/reference amino acid sequence. Mutations are
-            defined as positions where a sequence differs from this reference.
+    """Per-sequence divergence from the batch consensus.
 
     Output columns (prefixed by step_name):
-        _total_muts: Total number of mutations vs the reference.
-        _marginal_count: Number of mutations exclusive to this sequence
-            (not shared with any other batch member).
-        _marginal_fraction: Fraction of this sequence's mutations that are
-            exclusive.
-        _fractional_score: Sum of 1/k credits across all mutations, where
-            k is the number of batch members sharing each mutation.
-        _fractional_normalized: Fractional score divided by total mutations
-            (average 1/k across this sequence's mutations).
+        _consensus_divergence: Number of positions where this sequence's AA
+            is not among the batch's modal AA(s) at that position.
+        _consensus_divergence_fraction: Above, divided by sequence length.
     """
-    ref_seq = cfg.ref_seq
     sequences = df_input["sequence"].tolist()
+    if not sequences:
+        return df_input
 
-    mutation_sets = _get_mutation_sets(sequences, ref_seq)
-    global_counts = _mutation_counts(mutation_sets)
+    if len({len(s) for s in sequences}) != 1:
+        raise ValueError("All sequences in batch must have the same length.")
+
+    consensus = _consensus_sets(sequences)
+    seq_len = len(consensus)
 
     metrics_list = []
-    for idx in range(len(sequences)):
-        my_muts = mutation_sets[idx]
-        total_muts = len(my_muts)
-
-        marginal_count = sum(1 for m in my_muts if global_counts[m] == 1)
-
-        fractional_score = sum(1.0 / global_counts[m] for m in my_muts)
-
+    for idx, seq in enumerate(sequences):
+        divergence = sum(1 for i, aa in enumerate(seq) if aa not in consensus[i])
         metrics_list.append({
             "name": df_input.iloc[idx]["name"],
-            f"{step_name}_total_muts": total_muts,
-            f"{step_name}_marginal_count": marginal_count,
-            f"{step_name}_marginal_fraction": marginal_count / max(total_muts, 1),
-            f"{step_name}_fractional_score": fractional_score,
-            f"{step_name}_fractional_normalized": fractional_score / max(total_muts, 1),
+            f"{step_name}_consensus_divergence": divergence,
+            f"{step_name}_consensus_divergence_fraction": divergence / seq_len,
         })
 
     output_df = pd.DataFrame(metrics_list)


### PR DESCRIPTION
## Summary
- Rewrites `mutation_diversity_from_df` to be reference-free: per-sequence divergence from the per-position batch consensus (modal AA, ties treated as multi-modal).
- Drops the five old columns (`_total_muts`, `_marginal_count`, `_marginal_fraction`, `_fractional_score`, `_fractional_normalized`) in favor of `_consensus_divergence` and `_consensus_divergence_fraction`.
- `cfg` no longer requires `ref_seq`.
- Updates the commented example block in `config/design/denovo_petase.yaml` to point at the new column name.

## Test plan
- [ ] Smoke-run a short design loop with `mutation_diversity` uncommented in a training config and confirm the new columns appear in the rollout dataframe.
- [ ] Confirm no other configs/scripts reference the old metric names (grep is clean as of this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)